### PR TITLE
Don't slurp.

### DIFF
--- a/lib/Mojolicious/Plugin/Directory.pm
+++ b/lib/Mojolicious/Plugin/Directory.pm
@@ -95,8 +95,7 @@ sub render_file {
     my $handler = shift;
     $handler->( $c, $path ) if ( ref $handler eq 'CODE' );
     return if ( $c->tx->res->code );
-    my $data = Mojo::File::slurp($path);
-    $c->render( data => $data, format => get_ext($path) || 'txt' );
+    Mojolicious::Static->new->dispatch($c);
 }
 
 sub render_indexes {


### PR DESCRIPTION
Mojolicious already has a perfectly good way of dealing with large
static files without wasting any memory, so make use of
Mojolicious::Static.