### PR TITLE
Fixing bug (?) under Mojo 9.x for t/auto_index.t

### DIFF
--- a/lib/Mojolicious/Plugin/Directory.pm
+++ b/lib/Mojolicious/Plugin/Directory.pm
@@ -71,7 +71,11 @@ sub register {
                     return;
                 }
 
-                render_indexes( $c, $path, $json ) unless not $auto_index;
+                if( $auto_index ) {
+                    render_indexes( $c, $path, $json );
+                } else {
+                    $c->reply->not_found;
+                }
             }
         },
     );


### PR DESCRIPTION
In `before_dispatch` hook rather than falling through if the directory
exists but `auto_index` is disabled explicitly reply `not_found` so
that returns 404 (rather than 500).

Not a Mojo expert but this at least got me running under 9.13.  Fixes #9 